### PR TITLE
Fix capitalization of The Hague

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # SyntheticPopulationNL
-This repository aims to create a synthetic population for the country of the Netherlands based on the open source data available from the Central Bureau of Statistics of Netherlands.  The initial prototype of the model will focus only on the city of the Hague and create a resolution on the 4 level postcode of neighbourhoods.
+This repository aims to create a synthetic population for the country of the Netherlands based on the open source data available from the Central Bureau of Statistics of Netherlands.  The initial prototype of the model will focus only on the city of The Hague and create a resolution on the 4 level postcode of neighbourhoods.


### PR DESCRIPTION
## Summary
- fix capitalization of **The Hague** in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea79e7984832a826b81754d4d0d80